### PR TITLE
Removing dependency for library calls

### DIFF
--- a/R/printCrudeAndAdjustedModel.R
+++ b/R/printCrudeAndAdjustedModel.R
@@ -618,7 +618,7 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
       describeMean <- get(describeMean)
     }
   } else {
-    describeFactors <- Gmisc::describeMean
+    describeMean <- Gmisc::describeMean
   }
   
   if(exists("describeProp")){
@@ -626,7 +626,7 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
       describeProp <- get(describeProp)
     }
   } else {
-    describeFactors <- Gmisc::describeProp
+    describeProp <- Gmisc::describeProp
   }
   
   if(exists("describeFactors")){

--- a/R/printCrudeAndAdjustedModel.R
+++ b/R/printCrudeAndAdjustedModel.R
@@ -616,25 +616,25 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
   if(exists("describeMean")){
     if (is.character(describeMean)){
       describeMean <- get(describeMean)
-    } else {
-      describeMean <- Gmisc::describeMean
     }
+  } else {
+    describeFactors <- Gmisc::describeMean
   }
   
   if(exists("describeProp")){
     if (is.character(describeProp)){
       describeProp <- get(describeProp)
-    } else {
-      describeProp <- Gmisc::describeProp
     }
+  } else {
+    describeFactors <- Gmisc::describeProp
   }
   
   if(exists("describeFactors")){
     if (is.character(describeFactors)){
       describeFactors <- get(describeFactors)
-    } else {
-      describeFactors <- Gmisc::describeFactors
     }
+  } else {
+    describeFactors <- Gmisc::describeFactors
   }
 
   desc_list$continuous_fn <- describeMean

--- a/R/printCrudeAndAdjustedModel.R
+++ b/R/printCrudeAndAdjustedModel.R
@@ -613,7 +613,7 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
          digits = digits,
          colnames = colnames)
   
-  if(exists(describeMean)){
+  if(exists("describeMean")){
     if (is.character(describeMean)){
       describeMean <- get(describeMean)
     } else {
@@ -621,7 +621,7 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
     }
   }
   
-  if(exists(describeProp)){
+  if(exists("describeProp")){
     if (is.character(describeProp)){
       describeProp <- get(describeProp)
     } else {
@@ -629,7 +629,7 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
     }
   }
   
-  if(exists(describeFactors)){
+  if(exists("describeFactors")){
     if (is.character(describeFactors)){
       describeFactors <- get(describeFactors)
     } else {

--- a/R/printCrudeAndAdjustedModel.R
+++ b/R/printCrudeAndAdjustedModel.R
@@ -601,9 +601,9 @@ latex.printCrudeAndAdjusted <- function(object, ...){
 #' @export
 caDescribeOpts <- function(show_tot_perc    = FALSE,
                             numb_first       = TRUE,
-                           continuous_fn    = describeMean,
-                           prop_fn          = describeFactors,
-                           factor_fn        = describeFactors,
+                           continuous_fn    = Gmisc::describeMean,
+                           prop_fn          = Gmisc::describeFactors,
+                           factor_fn        = Gmisc::describeFactors,
                            digits           = 1,
                            colnames         = c("Total", "Event")){
   desc_list <- 
@@ -613,14 +613,29 @@ caDescribeOpts <- function(show_tot_perc    = FALSE,
          digits = digits,
          colnames = colnames)
   
-  if (is.character(describeMean))
-    describeMean <- get(describeMean)
+  if(exists(describeMean)){
+    if (is.character(describeMean)){
+      describeMean <- get(describeMean)
+    } else {
+      describeMean <- Gmisc::describeMean
+    }
+  }
   
-  if (is.character(describeProp))
-    describeProp <- get(describeProp)
+  if(exists(describeProp)){
+    if (is.character(describeProp)){
+      describeProp <- get(describeProp)
+    } else {
+      describeProp <- Gmisc::describeProp
+    }
+  }
   
-  if (is.character(describeFactors))
-    describeFactors <- get(describeFactors)
+  if(exists(describeFactors)){
+    if (is.character(describeFactors)){
+      describeFactors <- get(describeFactors)
+    } else {
+      describeFactors <- Gmisc::describeFactors
+    }
+  }
 
   desc_list$continuous_fn <- describeMean
   desc_list$prop_fn <- describeProp


### PR DESCRIPTION
This should make it so that people can just call

Greg::printCrudeAndAdjustedModel

without a library call to Gmisc or Greg.